### PR TITLE
Replaces OffsetDateTime with custom Date serde

### DIFF
--- a/java/src/main/java/com/ibm/watson/data/client/model/ArtifactMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ArtifactMetadata.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ibm.watson.data.client.model.enums.ArtifactState;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -29,8 +29,8 @@ public class ArtifactMetadata {
 
     private String artifactId;
     private String artifactType;
-    private OffsetDateTime effectiveEndDate;
-    private OffsetDateTime effectiveStartDate;
+    private Date effectiveEndDate;
+    private Date effectiveStartDate;
     private String name;
     private Category parentCategory;
     private String publishedAncestorId;
@@ -65,7 +65,7 @@ public class ArtifactMetadata {
     public String getArtifactType() { return artifactType; }
     public void setArtifactType(String artifactType) { this.artifactType = artifactType; }
 
-    public ArtifactMetadata effectiveEndDate(OffsetDateTime effectiveEndDate) {
+    public ArtifactMetadata effectiveEndDate(Date effectiveEndDate) {
         this.effectiveEndDate = effectiveEndDate;
         return this;
     }
@@ -77,10 +77,10 @@ public class ArtifactMetadata {
     @javax.annotation.Nullable
     @JsonProperty("effective_end_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveEndDate() { return effectiveEndDate; }
-    public void setEffectiveEndDate(OffsetDateTime effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
+    public Date getEffectiveEndDate() { return effectiveEndDate; }
+    public void setEffectiveEndDate(Date effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
 
-    public ArtifactMetadata effectiveStartDate(OffsetDateTime effectiveStartDate) {
+    public ArtifactMetadata effectiveStartDate(Date effectiveStartDate) {
         this.effectiveStartDate = effectiveStartDate;
         return this;
     }
@@ -91,8 +91,8 @@ public class ArtifactMetadata {
      **/
     @JsonProperty("effective_start_date")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getEffectiveStartDate() { return effectiveStartDate; }
-    public void setEffectiveStartDate(OffsetDateTime effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
+    public Date getEffectiveStartDate() { return effectiveStartDate; }
+    public void setEffectiveStartDate(Date effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
 
     public ArtifactMetadata name(String name) {
         this.name = name;

--- a/java/src/main/java/com/ibm/watson/data/client/model/ArtifactWorkflowData.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ArtifactWorkflowData.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ibm.watson.data.client.model.enums.GlossaryObjectDraftMode;
 import com.ibm.watson.data.client.model.enums.WorkflowAction;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -33,8 +33,8 @@ public class ArtifactWorkflowData {
     private WorkflowAction action;
     private String baseUrl;
     private GlossaryObjectDraftMode draftMode;
-    private OffsetDateTime oldEffectiveEndDate;
-    private OffsetDateTime oldEffectiveStartDate;
+    private Date oldEffectiveEndDate;
+    private Date oldEffectiveStartDate;
     private Category oldParentCategory;
     private List<Workflow> workflows = null;
 
@@ -81,7 +81,7 @@ public class ArtifactWorkflowData {
     public GlossaryObjectDraftMode getDraftMode() { return draftMode; }
     public void setDraftMode(GlossaryObjectDraftMode draftMode) { this.draftMode = draftMode; }
 
-    public ArtifactWorkflowData oldEffectiveEndDate(OffsetDateTime oldEffectiveEndDate) {
+    public ArtifactWorkflowData oldEffectiveEndDate(Date oldEffectiveEndDate) {
         this.oldEffectiveEndDate = oldEffectiveEndDate;
         return this;
     }
@@ -93,10 +93,10 @@ public class ArtifactWorkflowData {
     @javax.annotation.Nullable
     @JsonProperty("old_effective_end_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getOldEffectiveEndDate() { return oldEffectiveEndDate; }
-    public void setOldEffectiveEndDate(OffsetDateTime oldEffectiveEndDate) { this.oldEffectiveEndDate = oldEffectiveEndDate; }
+    public Date getOldEffectiveEndDate() { return oldEffectiveEndDate; }
+    public void setOldEffectiveEndDate(Date oldEffectiveEndDate) { this.oldEffectiveEndDate = oldEffectiveEndDate; }
 
-    public ArtifactWorkflowData oldEffectiveStartDate(OffsetDateTime oldEffectiveStartDate) {
+    public ArtifactWorkflowData oldEffectiveStartDate(Date oldEffectiveStartDate) {
         this.oldEffectiveStartDate = oldEffectiveStartDate;
         return this;
     }
@@ -107,8 +107,8 @@ public class ArtifactWorkflowData {
      **/
     @JsonProperty("old_effective_start_date")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getOldEffectiveStartDate() { return oldEffectiveStartDate; }
-    public void setOldEffectiveStartDate(OffsetDateTime oldEffectiveStartDate) { this.oldEffectiveStartDate = oldEffectiveStartDate; }
+    public Date getOldEffectiveStartDate() { return oldEffectiveStartDate; }
+    public void setOldEffectiveStartDate(Date oldEffectiveStartDate) { this.oldEffectiveStartDate = oldEffectiveStartDate; }
 
     public ArtifactWorkflowData oldParentCategory(Category oldParentCategory) {
         this.oldParentCategory = oldParentCategory;

--- a/java/src/main/java/com/ibm/watson/data/client/model/AssetRatingMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/AssetRatingMetadata.java
@@ -17,8 +17,12 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.ibm.watson.data.client.serde.DateTimeNoMilliDeserializer;
+import com.ibm.watson.data.client.serde.DateTimeNoMilliSerializer;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -30,8 +34,15 @@ public class AssetRatingMetadata {
     private String assetId;
     private String creator;
     private String creatorId;
-    private OffsetDateTime createdAt;
-    private OffsetDateTime updatedAt;
+
+    @JsonSerialize(using = DateTimeNoMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeNoMilliDeserializer.class)
+    private Date createdAt;
+
+    @JsonSerialize(using = DateTimeNoMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeNoMilliDeserializer.class)
+    private Date updatedAt;
+
     private Long revisionId;
 
     public AssetRatingMetadata assetRatingId(String assetRatingId) {
@@ -88,7 +99,7 @@ public class AssetRatingMetadata {
     @javax.annotation.Nullable
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
+    public Date getCreatedAt() { return createdAt; }
 
     /**
      * RFC 3339 timestamp when the asset rating was updated (system managed)
@@ -97,7 +108,7 @@ public class AssetRatingMetadata {
     @javax.annotation.Nullable
     @JsonProperty("updated_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getUpdatedAt() { return updatedAt; }
+    public Date getUpdatedAt() { return updatedAt; }
 
     /**
      * identifier for asset associated with this rating (system managed)

--- a/java/src/main/java/com/ibm/watson/data/client/model/CommentMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/CommentMetadata.java
@@ -18,7 +18,7 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -30,8 +30,8 @@ public class CommentMetadata {
     private String assetVersionId;
     private String assetAncestorId;
     private String modifiedBy;
-    private OffsetDateTime modifiedAt;
-    private OffsetDateTime createdAt;
+    private Date modifiedAt;
+    private Date createdAt;
 
     public CommentMetadata id(String id) {
         this.id = id;
@@ -93,7 +93,7 @@ public class CommentMetadata {
     public String getModifiedBy() { return modifiedBy; }
     public void setModifiedBy(String modifiedBy) { this.modifiedBy = modifiedBy; }
 
-    public CommentMetadata modifiedAt(OffsetDateTime modifiedAt) {
+    public CommentMetadata modifiedAt(Date modifiedAt) {
         this.modifiedAt = modifiedAt;
         return this;
     }
@@ -105,10 +105,10 @@ public class CommentMetadata {
     @javax.annotation.Nullable
     @JsonProperty("modified_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getModifiedAt() { return modifiedAt; }
-    public void setModifiedAt(OffsetDateTime modifiedAt) { this.modifiedAt = modifiedAt; }
+    public Date getModifiedAt() { return modifiedAt; }
+    public void setModifiedAt(Date modifiedAt) { this.modifiedAt = modifiedAt; }
 
-    public CommentMetadata createdAt(OffsetDateTime createdAt) {
+    public CommentMetadata createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -120,8 +120,8 @@ public class CommentMetadata {
     @javax.annotation.Nullable
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     @Override
     public boolean equals(java.lang.Object o) {

--- a/java/src/main/java/com/ibm/watson/data/client/model/CommitInfo.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/CommitInfo.java
@@ -18,7 +18,7 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -26,11 +26,11 @@ import java.util.Objects;
  */
 public class CommitInfo {
 
-    private OffsetDateTime committedAt;
+    private Date committedAt;
     private String commitMessage;
     private Long previousRevision;
 
-    public CommitInfo committedAt(OffsetDateTime committedAt) {
+    public CommitInfo committedAt(Date committedAt) {
         this.committedAt = committedAt;
         return this;
     }
@@ -38,8 +38,8 @@ public class CommitInfo {
     @javax.annotation.Nullable
     @JsonProperty("committed_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCommittedAt() { return committedAt; }
-    public void setCommittedAt(OffsetDateTime committedAt) { this.committedAt = committedAt; }
+    public Date getCommittedAt() { return committedAt; }
+    public void setCommittedAt(Date committedAt) { this.committedAt = committedAt; }
 
     public CommitInfo commitMessage(String commitMessage) {
         this.commitMessage = commitMessage;

--- a/java/src/main/java/com/ibm/watson/data/client/model/ConnectionMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ConnectionMetadata.java
@@ -18,9 +18,7 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -29,7 +27,7 @@ import java.util.Objects;
 public class ConnectionMetadata extends Metadata {
 
     private String assetId;
-    private OffsetDateTime createTime;
+    private Date createTime;
     private String creatorId;
     private String projectId;
     private String catalogId;
@@ -46,7 +44,7 @@ public class ConnectionMetadata extends Metadata {
     public String getAssetId() { return assetId; }
     public void setAssetId(String assetId) { this.assetId = assetId; }
 
-    public ConnectionMetadata createTime(OffsetDateTime createTime) {
+    public ConnectionMetadata createTime(Date createTime) {
         this.createTime = createTime;
         return this;
     }
@@ -54,8 +52,8 @@ public class ConnectionMetadata extends Metadata {
     @javax.annotation.Nullable
     @JsonProperty("create_time")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreateTime() { return createTime; }
-    public void setCreateTime(OffsetDateTime createTime) { this.createTime = createTime; }
+    public Date getCreateTime() { return createTime; }
+    public void setCreateTime(Date createTime) { this.createTime = createTime; }
 
     public ConnectionMetadata creatorId(String creatorId) {
         this.creatorId = creatorId;

--- a/java/src/main/java/com/ibm/watson/data/client/model/ConnectionMetadataUsage.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ConnectionMetadataUsage.java
@@ -18,7 +18,7 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -26,11 +26,11 @@ import java.util.Objects;
  */
 public class ConnectionMetadataUsage {
 
-    private OffsetDateTime lastAccessTime;
+    private Date lastAccessTime;
     private String lastAccessorId;
     private Integer accessCount;
 
-    public ConnectionMetadataUsage lastAccessTime(OffsetDateTime lastAccessTime) {
+    public ConnectionMetadataUsage lastAccessTime(Date lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
         return this;
     }
@@ -41,8 +41,8 @@ public class ConnectionMetadataUsage {
      **/
     @JsonProperty("last_access_time")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getLastAccessTime() { return lastAccessTime; }
-    public void setLastAccessTime(OffsetDateTime lastAccessTime) { this.lastAccessTime = lastAccessTime; }
+    public Date getLastAccessTime() { return lastAccessTime; }
+    public void setLastAccessTime(Date lastAccessTime) { this.lastAccessTime = lastAccessTime; }
 
     public ConnectionMetadataUsage lastAccessorId(String lastAccessorId) {
         this.lastAccessorId = lastAccessorId;

--- a/java/src/main/java/com/ibm/watson/data/client/model/DraftArtifact.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/DraftArtifact.java
@@ -17,8 +17,8 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -33,8 +33,8 @@ public class DraftArtifact {
     private String workflowId;
     private String type;
     private String longDescription;
-    private OffsetDateTime createdAt;
-    private OffsetDateTime modifiedAt;
+    private Date createdAt;
+    private Date modifiedAt;
     private String createdBy;
     private String modifiedBy;
     private SearchRelatedAsset parentCategory;
@@ -134,7 +134,7 @@ public class DraftArtifact {
     public String getLongDescription() { return longDescription; }
     public void setLongDescription(String longDescription) { this.longDescription = longDescription; }
 
-    public DraftArtifact createdAt(OffsetDateTime createdAt) {
+    public DraftArtifact createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -146,10 +146,10 @@ public class DraftArtifact {
     @javax.annotation.Nullable
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
-    public DraftArtifact modifiedAt(OffsetDateTime modifiedAt) {
+    public DraftArtifact modifiedAt(Date modifiedAt) {
         this.modifiedAt = modifiedAt;
         return this;
     }
@@ -161,8 +161,8 @@ public class DraftArtifact {
     @javax.annotation.Nullable
     @JsonProperty("modified_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getModifiedAt() { return modifiedAt; }
-    public void setModifiedAt(OffsetDateTime modifiedAt) { this.modifiedAt = modifiedAt; }
+    public Date getModifiedAt() { return modifiedAt; }
+    public void setModifiedAt(Date modifiedAt) { this.modifiedAt = modifiedAt; }
 
     public DraftArtifact createdBy(String createdBy) {
         this.createdBy = createdBy;

--- a/java/src/main/java/com/ibm/watson/data/client/model/FormPropertyInput.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/FormPropertyInput.java
@@ -17,7 +17,7 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -25,12 +25,12 @@ import java.util.Objects;
  */
 public class FormPropertyInput {
 
-    private OffsetDateTime dateValue;
+    private Date dateValue;
     private String id;
     private Long longValue;
     private String value;
 
-    public FormPropertyInput dateValue(OffsetDateTime dateValue) {
+    public FormPropertyInput dateValue(Date dateValue) {
         this.dateValue = dateValue;
         return this;
     }
@@ -42,8 +42,8 @@ public class FormPropertyInput {
     @javax.annotation.Nullable
     @JsonProperty("date_value")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getDateValue() { return dateValue; }
-    public void setDateValue(OffsetDateTime dateValue) { this.dateValue = dateValue; }
+    public Date getDateValue() { return dateValue; }
+    public void setDateValue(Date dateValue) { this.dateValue = dateValue; }
 
     public FormPropertyInput id(String id) {
         this.id = id;

--- a/java/src/main/java/com/ibm/watson/data/client/model/GlossaryObjectMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/GlossaryObjectMetadata.java
@@ -17,11 +17,15 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.ibm.watson.data.client.model.enums.GlossaryObjectDraftMode;
 import com.ibm.watson.data.client.model.enums.GlossaryObjectState;
+import com.ibm.watson.data.client.serde.DateTimeMilliDeserializer;
+import com.ibm.watson.data.client.serde.DateTimeMilliSerializer;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,12 +44,20 @@ public class GlossaryObjectMetadata {
     private GlossaryObjectDraftMode draftMode;
     private String publishedAncestorId;
     private String draftAncestorId;
-    private OffsetDateTime effectiveStartDate;
-    private OffsetDateTime effectiveEndDate;
+    private Date effectiveStartDate;
+    private Date effectiveEndDate;
     private String createdBy;
-    private OffsetDateTime createdAt;
+
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date createdAt;
+
     private String modifiedBy;
-    private OffsetDateTime modifiedAt;
+
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date modifiedAt;
+
     private String revision;
     private String name;
     private String shortDescription;
@@ -211,7 +223,7 @@ public class GlossaryObjectMetadata {
     public String getDraftAncestorId() { return draftAncestorId; }
     public void setDraftAncestorId(String draftAncestorId) { this.draftAncestorId = draftAncestorId; }
 
-    public GlossaryObjectMetadata effectiveStartDate(OffsetDateTime effectiveStartDate) {
+    public GlossaryObjectMetadata effectiveStartDate(Date effectiveStartDate) {
         this.effectiveStartDate = effectiveStartDate;
         return this;
     }
@@ -223,10 +235,10 @@ public class GlossaryObjectMetadata {
     @javax.annotation.Nullable
     @JsonProperty("effective_start_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveStartDate() { return effectiveStartDate; }
-    public void setEffectiveStartDate(OffsetDateTime effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
+    public Date getEffectiveStartDate() { return effectiveStartDate; }
+    public void setEffectiveStartDate(Date effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
 
-    public GlossaryObjectMetadata effectiveEndDate(OffsetDateTime effectiveEndDate) {
+    public GlossaryObjectMetadata effectiveEndDate(Date effectiveEndDate) {
         this.effectiveEndDate = effectiveEndDate;
         return this;
     }
@@ -238,8 +250,8 @@ public class GlossaryObjectMetadata {
     @javax.annotation.Nullable
     @JsonProperty("effective_end_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveEndDate() { return effectiveEndDate; }
-    public void setEffectiveEndDate(OffsetDateTime effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
+    public Date getEffectiveEndDate() { return effectiveEndDate; }
+    public void setEffectiveEndDate(Date effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
 
     public GlossaryObjectMetadata createdBy(String createdBy) {
         this.createdBy = createdBy;
@@ -256,7 +268,7 @@ public class GlossaryObjectMetadata {
     public String getCreatedBy() { return createdBy; }
     public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
 
-    public GlossaryObjectMetadata createdAt(OffsetDateTime createdAt) {
+    public GlossaryObjectMetadata createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -268,8 +280,8 @@ public class GlossaryObjectMetadata {
     @javax.annotation.Nullable
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     public GlossaryObjectMetadata modifiedBy(String modifiedBy) {
         this.modifiedBy = modifiedBy;
@@ -286,7 +298,7 @@ public class GlossaryObjectMetadata {
     public String getModifiedBy() { return modifiedBy; }
     public void setModifiedBy(String modifiedBy) { this.modifiedBy = modifiedBy; }
 
-    public GlossaryObjectMetadata modifiedAt(OffsetDateTime modifiedAt) {
+    public GlossaryObjectMetadata modifiedAt(Date modifiedAt) {
         this.modifiedAt = modifiedAt;
         return this;
     }
@@ -298,8 +310,8 @@ public class GlossaryObjectMetadata {
     @javax.annotation.Nullable
     @JsonProperty("modified_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getModifiedAt() { return modifiedAt; }
-    public void setModifiedAt(OffsetDateTime modifiedAt) { this.modifiedAt = modifiedAt; }
+    public Date getModifiedAt() { return modifiedAt; }
+    public void setModifiedAt(Date modifiedAt) { this.modifiedAt = modifiedAt; }
 
     public GlossaryObjectMetadata revision(String revision) {
         this.revision = revision;

--- a/java/src/main/java/com/ibm/watson/data/client/model/JobEntityJob.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/JobEntityJob.java
@@ -18,7 +18,7 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -31,7 +31,7 @@ public class JobEntityJob {
     private String assetRefType;
     private String lastRunStatus;
     private Integer lastRunStatusTimestamp;
-    private OffsetDateTime lastRunTime;
+    private Date lastRunTime;
     private String lastRunInitiator;
     private String schedule;
     private JobEntityJobScheduleInfo scheduleInfo;
@@ -113,7 +113,7 @@ public class JobEntityJob {
     public Integer getLastRunStatusTimestamp() { return lastRunStatusTimestamp; }
     public void setLastRunStatusTimestamp(Integer lastRunStatusTimestamp) { this.lastRunStatusTimestamp = lastRunStatusTimestamp; }
 
-    public JobEntityJob lastRunTime(OffsetDateTime lastRunTime) {
+    public JobEntityJob lastRunTime(Date lastRunTime) {
         this.lastRunTime = lastRunTime;
         return this;
     }
@@ -125,8 +125,8 @@ public class JobEntityJob {
     @javax.annotation.Nullable
     @JsonProperty("last_run_time")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getLastRunTime() { return lastRunTime; }
-    public void setLastRunTime(OffsetDateTime lastRunTime) { this.lastRunTime = lastRunTime; }
+    public Date getLastRunTime() { return lastRunTime; }
+    public void setLastRunTime(Date lastRunTime) { this.lastRunTime = lastRunTime; }
 
     public JobEntityJob lastRunInitiator(String lastRunInitiator) {
         this.lastRunInitiator = lastRunInitiator;

--- a/java/src/main/java/com/ibm/watson/data/client/model/MemberRegistration.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/MemberRegistration.java
@@ -17,7 +17,7 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -30,7 +30,7 @@ public class MemberRegistration {
     private String serverName;
     private String serverType;
     private String organizationName;
-    private OffsetDateTime registrationTime;
+    private Date registrationTime;
     private Connection repositoryConnection;
 
     public MemberRegistration metadataCollectionId(String metadataCollectionId) {
@@ -108,7 +108,7 @@ public class MemberRegistration {
     public String getOrganizationName() { return organizationName; }
     public void setOrganizationName(String organizationName) { this.organizationName = organizationName; }
 
-    public MemberRegistration registrationTime(OffsetDateTime registrationTime) {
+    public MemberRegistration registrationTime(Date registrationTime) {
         this.registrationTime = registrationTime;
         return this;
     }
@@ -120,8 +120,8 @@ public class MemberRegistration {
     @javax.annotation.Nullable
     @JsonProperty("registrationTime")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getRegistrationTime() { return registrationTime; }
-    public void setRegistrationTime(OffsetDateTime registrationTime) { this.registrationTime = registrationTime; }
+    public Date getRegistrationTime() { return registrationTime; }
+    public void setRegistrationTime(Date registrationTime) { this.registrationTime = registrationTime; }
 
     public MemberRegistration repositoryConnection(Connection repositoryConnection) {
         this.repositoryConnection = repositoryConnection;

--- a/java/src/main/java/com/ibm/watson/data/client/model/MetadataAsset.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/MetadataAsset.java
@@ -17,9 +17,13 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.ibm.watson.data.client.serde.DateTimeNoMilliDeserializer;
+import com.ibm.watson.data.client.serde.DateTimeNoMilliSerializer;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,7 +44,7 @@ public class MetadataAsset extends MetadataHeader {
     private Long totalRatings;
     private String catalogId;
     private Long created;
-    private OffsetDateTime createdAt;
+    private Date createdAt;
     private String ownerId;
     private Long size;
     private Double version;
@@ -175,7 +179,7 @@ public class MetadataAsset extends MetadataHeader {
     public Long getCreated() { return created; }
     public void setCreated(Long created) { this.created = created; }
 
-    public MetadataAsset createdAt(OffsetDateTime createdAt) {
+    public MetadataAsset createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -183,8 +187,8 @@ public class MetadataAsset extends MetadataHeader {
     @javax.annotation.Nullable
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     public MetadataAsset ownerId(String ownerId) {
         this.ownerId = ownerId;

--- a/java/src/main/java/com/ibm/watson/data/client/model/MetadataUsage.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/MetadataUsage.java
@@ -18,7 +18,7 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -26,15 +26,15 @@ import java.util.Objects;
  */
 public class MetadataUsage {
 
-    private OffsetDateTime lastUpdatedAt;
+    private Date lastUpdatedAt;
     private String lastUpdaterId;
     private Long lastUpdateTime;
-    private OffsetDateTime lastAccessedAt;
+    private Date lastAccessedAt;
     private Long lastAccessTime;
     private String lastAccessorId;
     private Integer accessCount;
 
-    public MetadataUsage lastUpdatedAt(OffsetDateTime lastUpdatedAt) {
+    public MetadataUsage lastUpdatedAt(Date lastUpdatedAt) {
         this.lastUpdatedAt = lastUpdatedAt;
         return this;
     }
@@ -47,8 +47,8 @@ public class MetadataUsage {
      **/
     @JsonProperty("last_updated_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getLastUpdatedAt() { return lastUpdatedAt; }
-    public void setLastUpdatedAt(OffsetDateTime lastUpdatedAt) { this.lastUpdatedAt = lastUpdatedAt; }
+    public Date getLastUpdatedAt() { return lastUpdatedAt; }
+    public void setLastUpdatedAt(Date lastUpdatedAt) { this.lastUpdatedAt = lastUpdatedAt; }
 
     public MetadataUsage lastUpdaterId(String lastUpdaterId) {
         this.lastUpdaterId = lastUpdaterId;
@@ -78,7 +78,7 @@ public class MetadataUsage {
     public Long getLastUpdateTime() { return lastUpdateTime; }
     public void setLastUpdateTime(Long lastUpdateTime) { this.lastUpdateTime = lastUpdateTime; }
 
-    public MetadataUsage lastAccessedAt(OffsetDateTime lastAccessedAt) {
+    public MetadataUsage lastAccessedAt(Date lastAccessedAt) {
         this.lastAccessedAt = lastAccessedAt;
         return this;
     }
@@ -91,8 +91,8 @@ public class MetadataUsage {
      **/
     @JsonProperty("last_accessed_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getLastAccessedAt() { return lastAccessedAt; }
-    public void setLastAccessedAt(OffsetDateTime lastAccessedAt) { this.lastAccessedAt = lastAccessedAt; }
+    public Date getLastAccessedAt() { return lastAccessedAt; }
+    public void setLastAccessedAt(Date lastAccessedAt) { this.lastAccessedAt = lastAccessedAt; }
 
     public MetadataUsage lastAccessTime(Long lastAccessTime) {
         this.lastAccessTime = lastAccessTime;

--- a/java/src/main/java/com/ibm/watson/data/client/model/Metric.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/Metric.java
@@ -15,11 +15,11 @@
  */
 package com.ibm.watson.data.client.model;
 
+import java.util.Date;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,13 +28,13 @@ import java.util.Map;
  */
 public class Metric {
 
-    private OffsetDateTime timestamp;
+    private Date timestamp;
     private Integer iteration;
     private Map<String, BigDecimal> mlMetrics = null;
     private Map<String, MlFederatedMetric> mlFederatedMetrics = null;
     private MetricsContext context;
 
-    public Metric timestamp(OffsetDateTime timestamp) {
+    public Metric timestamp(Date timestamp) {
         this.timestamp = timestamp;
         return this;
     }
@@ -45,8 +45,8 @@ public class Metric {
      **/
     @JsonProperty("timestamp")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getTimestamp() { return timestamp; }
-    public void setTimestamp(OffsetDateTime timestamp) { this.timestamp = timestamp; }
+    public Date getTimestamp() { return timestamp; }
+    public void setTimestamp(Date timestamp) { this.timestamp = timestamp; }
 
     public Metric iteration(Integer iteration) {
         this.iteration = iteration;

--- a/java/src/main/java/com/ibm/watson/data/client/model/NewCookie.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/NewCookie.java
@@ -17,7 +17,7 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -32,7 +32,7 @@ public class NewCookie {
     private String domain;
     private String comment;
     private Integer maxAge;
-    private OffsetDateTime expiry;
+    private Date expiry;
     private Boolean secure;
     private Boolean httpOnly;
 
@@ -141,7 +141,7 @@ public class NewCookie {
     public Integer getMaxAge() { return maxAge; }
     public void setMaxAge(Integer maxAge) { this.maxAge = maxAge; }
 
-    public NewCookie expiry(OffsetDateTime expiry) {
+    public NewCookie expiry(Date expiry) {
         this.expiry = expiry;
         return this;
     }
@@ -153,8 +153,8 @@ public class NewCookie {
     @javax.annotation.Nullable
     @JsonProperty("expiry")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getExpiry() { return expiry; }
-    public void setExpiry(OffsetDateTime expiry) { this.expiry = expiry; }
+    public Date getExpiry() { return expiry; }
+    public void setExpiry(Date expiry) { this.expiry = expiry; }
 
     public NewCookie secure(Boolean secure) {
         this.secure = secure;

--- a/java/src/main/java/com/ibm/watson/data/client/model/NewDataClassEntity.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/NewDataClassEntity.java
@@ -18,8 +18,8 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,8 +30,8 @@ public class NewDataClassEntity extends DataClassEntity {
 
     private String name;
     private String shortDescription;
-    private OffsetDateTime effectiveStartDate;
-    private OffsetDateTime effectiveEndDate;
+    private Date effectiveStartDate;
+    private Date effectiveEndDate;
     private String workflowState;
     private List<String> tags = null;
     private List<String> stewardIds = null;
@@ -71,7 +71,7 @@ public class NewDataClassEntity extends DataClassEntity {
     public String getShortDescription() { return shortDescription; }
     public void setShortDescription(String shortDescription) { this.shortDescription = shortDescription; }
 
-    public NewDataClassEntity effectiveStartDate(OffsetDateTime effectiveStartDate) {
+    public NewDataClassEntity effectiveStartDate(Date effectiveStartDate) {
         this.effectiveStartDate = effectiveStartDate;
         return this;
     }
@@ -85,10 +85,10 @@ public class NewDataClassEntity extends DataClassEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_start_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveStartDate() { return effectiveStartDate; }
-    public void setEffectiveStartDate(OffsetDateTime effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
+    public Date getEffectiveStartDate() { return effectiveStartDate; }
+    public void setEffectiveStartDate(Date effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
 
-    public NewDataClassEntity effectiveEndDate(OffsetDateTime effectiveEndDate) {
+    public NewDataClassEntity effectiveEndDate(Date effectiveEndDate) {
         this.effectiveEndDate = effectiveEndDate;
         return this;
     }
@@ -102,8 +102,8 @@ public class NewDataClassEntity extends DataClassEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_end_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveEndDate() { return effectiveEndDate; }
-    public void setEffectiveEndDate(OffsetDateTime effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
+    public Date getEffectiveEndDate() { return effectiveEndDate; }
+    public void setEffectiveEndDate(Date effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
 
     public NewDataClassEntity workflowState(String workflowState) {
         this.workflowState = workflowState;

--- a/java/src/main/java/com/ibm/watson/data/client/model/NewPolicyEntity.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/NewPolicyEntity.java
@@ -18,8 +18,8 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,8 +30,8 @@ public class NewPolicyEntity extends GlossaryObjectEntity {
 
     private String name;
     private String shortDescription;
-    private OffsetDateTime effectiveStartDate;
-    private OffsetDateTime effectiveEndDate;
+    private Date effectiveStartDate;
+    private Date effectiveEndDate;
     private String workflowState;
     private List<String> tags = null;
     private NewRelationship parentPolicy;
@@ -73,7 +73,7 @@ public class NewPolicyEntity extends GlossaryObjectEntity {
     public String getShortDescription() { return shortDescription; }
     public void setShortDescription(String shortDescription) { this.shortDescription = shortDescription; }
 
-    public NewPolicyEntity effectiveStartDate(OffsetDateTime effectiveStartDate) {
+    public NewPolicyEntity effectiveStartDate(Date effectiveStartDate) {
         this.effectiveStartDate = effectiveStartDate;
         return this;
     }
@@ -87,10 +87,10 @@ public class NewPolicyEntity extends GlossaryObjectEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_start_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveStartDate() { return effectiveStartDate; }
-    public void setEffectiveStartDate(OffsetDateTime effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
+    public Date getEffectiveStartDate() { return effectiveStartDate; }
+    public void setEffectiveStartDate(Date effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
 
-    public NewPolicyEntity effectiveEndDate(OffsetDateTime effectiveEndDate) {
+    public NewPolicyEntity effectiveEndDate(Date effectiveEndDate) {
         this.effectiveEndDate = effectiveEndDate;
         return this;
     }
@@ -104,8 +104,8 @@ public class NewPolicyEntity extends GlossaryObjectEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_end_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveEndDate() { return effectiveEndDate; }
-    public void setEffectiveEndDate(OffsetDateTime effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
+    public Date getEffectiveEndDate() { return effectiveEndDate; }
+    public void setEffectiveEndDate(Date effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
 
     public NewPolicyEntity workflowState(String workflowState) {
         this.workflowState = workflowState;

--- a/java/src/main/java/com/ibm/watson/data/client/model/PolicyResourceMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/PolicyResourceMetadata.java
@@ -17,7 +17,7 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -27,9 +27,9 @@ import java.util.Objects;
 public class PolicyResourceMetadata {
 
     private String guid;
-    private OffsetDateTime createdAt;
+    private Date createdAt;
     private String creator;
-    private OffsetDateTime updatedAt;
+    private Date updatedAt;
     private String modifier;
 
     public PolicyResourceMetadata guid(String guid) {
@@ -46,7 +46,7 @@ public class PolicyResourceMetadata {
     public String getGuid() { return guid; }
     public void setGuid(String guid) { this.guid = guid; }
 
-    public PolicyResourceMetadata createdAt(OffsetDateTime createdAt) {
+    public PolicyResourceMetadata createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -57,8 +57,8 @@ public class PolicyResourceMetadata {
      **/
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     public PolicyResourceMetadata creator(String creator) {
         this.creator = creator;
@@ -74,7 +74,7 @@ public class PolicyResourceMetadata {
     public String getCreator() { return creator; }
     public void setCreator(String creator) { this.creator = creator; }
 
-    public PolicyResourceMetadata updatedAt(OffsetDateTime updatedAt) {
+    public PolicyResourceMetadata updatedAt(Date updatedAt) {
         this.updatedAt = updatedAt;
         return this;
     }
@@ -85,8 +85,8 @@ public class PolicyResourceMetadata {
      **/
     @JsonProperty("updated_at")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getUpdatedAt() { return updatedAt; }
-    public void setUpdatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; }
+    public Date getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
 
     public PolicyResourceMetadata modifier(String modifier) {
         this.modifier = modifier;

--- a/java/src/main/java/com/ibm/watson/data/client/model/ProjectToken.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ProjectToken.java
@@ -18,8 +18,8 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -28,14 +28,14 @@ import java.util.Objects;
  */
 public class ProjectToken {
 
-    private OffsetDateTime createdAt;
+    private Date createdAt;
     private String guid;
-    private OffsetDateTime lastUsedAt;
+    private Date lastUsedAt;
     private String name;
     private List<TokenScope> scopes = null;
     private String token;
 
-    public ProjectToken createdAt(OffsetDateTime createdAt) {
+    public ProjectToken createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -47,8 +47,8 @@ public class ProjectToken {
     @javax.annotation.Nullable
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     public ProjectToken guid(String guid) {
         this.guid = guid;
@@ -65,7 +65,7 @@ public class ProjectToken {
     public String getGuid() { return guid; }
     public void setGuid(String guid) { this.guid = guid; }
 
-    public ProjectToken lastUsedAt(OffsetDateTime lastUsedAt) {
+    public ProjectToken lastUsedAt(Date lastUsedAt) {
         this.lastUsedAt = lastUsedAt;
         return this;
     }
@@ -77,8 +77,8 @@ public class ProjectToken {
     @javax.annotation.Nullable
     @JsonProperty("last_used_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getLastUsedAt() { return lastUsedAt; }
-    public void setLastUsedAt(OffsetDateTime lastUsedAt) { this.lastUsedAt = lastUsedAt; }
+    public Date getLastUsedAt() { return lastUsedAt; }
+    public void setLastUsedAt(Date lastUsedAt) { this.lastUsedAt = lastUsedAt; }
 
     public ProjectToken name(String name) {
         this.name = name;

--- a/java/src/main/java/com/ibm/watson/data/client/model/ResourceMeta.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ResourceMeta.java
@@ -15,10 +15,15 @@
  */
 package com.ibm.watson.data.client.model;
 
+import java.util.Date;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.ibm.watson.data.client.serde.DateTimeMilliDeserializer;
+import com.ibm.watson.data.client.serde.DateTimeMilliSerializer;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,8 +35,15 @@ public class ResourceMeta {
     private String id;
     private String rev;
     private String owner;
-    private OffsetDateTime createdAt;
-    private OffsetDateTime modifiedAt;
+    
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date createdAt;
+
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date modifiedAt;
+
     private String parentId;
     private String name;
     private String description;
@@ -85,7 +97,7 @@ public class ResourceMeta {
     public String getOwner() { return owner; }
     public void setOwner(String owner) { this.owner = owner; }
 
-    public ResourceMeta createdAt(OffsetDateTime createdAt) {
+    public ResourceMeta createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -96,10 +108,10 @@ public class ResourceMeta {
      **/
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
-    public ResourceMeta modifiedAt(OffsetDateTime modifiedAt) {
+    public ResourceMeta modifiedAt(Date modifiedAt) {
         this.modifiedAt = modifiedAt;
         return this;
     }
@@ -111,8 +123,8 @@ public class ResourceMeta {
     @javax.annotation.Nullable
     @JsonProperty("modified_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getModifiedAt() { return modifiedAt; }
-    public void setModifiedAt(OffsetDateTime modifiedAt) { this.modifiedAt = modifiedAt; }
+    public Date getModifiedAt() { return modifiedAt; }
+    public void setModifiedAt(Date modifiedAt) { this.modifiedAt = modifiedAt; }
 
     public ResourceMeta parentId(String parentId) {
         this.parentId = parentId;

--- a/java/src/main/java/com/ibm/watson/data/client/model/ResourceMetaBaseCommitInfo.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ResourceMetaBaseCommitInfo.java
@@ -15,20 +15,20 @@
  */
 package com.ibm.watson.data.client.model;
 
+import java.util.Date;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
 
 /**
  * Information related to the revision. 
  */
 public class ResourceMetaBaseCommitInfo {
 
-    private OffsetDateTime committedAt;
+    private Date committedAt;
     private String commitMessage;
 
-    public ResourceMetaBaseCommitInfo committedAt(OffsetDateTime committedAt) {
+    public ResourceMetaBaseCommitInfo committedAt(Date committedAt) {
         this.committedAt = committedAt;
         return this;
     }
@@ -39,8 +39,8 @@ public class ResourceMetaBaseCommitInfo {
      **/
     @JsonProperty("committed_at")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getCommittedAt() { return committedAt; }
-    public void setCommittedAt(OffsetDateTime committedAt) { this.committedAt = committedAt; }
+    public Date getCommittedAt() { return committedAt; }
+    public void setCommittedAt(Date committedAt) { this.committedAt = committedAt; }
 
     public ResourceMetaBaseCommitInfo commitMessage(String commitMessage) {
         this.commitMessage = commitMessage;

--- a/java/src/main/java/com/ibm/watson/data/client/model/Response.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/Response.java
@@ -18,12 +18,7 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Response
@@ -39,8 +34,8 @@ public class Response {
     private List<String> allowedMethods = null;
     private Map<String, NewCookie> cookies = null;
     private EntityTag entityTag;
-    private OffsetDateTime date;
-    private OffsetDateTime lastModified;
+    private Date date;
+    private Date lastModified;
     private URI location;
     private List<Link> links = null;
     private Map<String, List<Object>> metadata = null;
@@ -198,7 +193,7 @@ public class Response {
     public EntityTag getEntityTag() { return entityTag; }
     public void setEntityTag(EntityTag entityTag) { this.entityTag = entityTag; }
 
-    public Response date(OffsetDateTime date) {
+    public Response date(Date date) {
         this.date = date;
         return this;
     }
@@ -210,10 +205,10 @@ public class Response {
     @javax.annotation.Nullable
     @JsonProperty("date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getDate() { return date; }
-    public void setDate(OffsetDateTime date) { this.date = date; }
+    public Date getDate() { return date; }
+    public void setDate(Date date) { this.date = date; }
 
-    public Response lastModified(OffsetDateTime lastModified) {
+    public Response lastModified(Date lastModified) {
         this.lastModified = lastModified;
         return this;
     }
@@ -225,8 +220,8 @@ public class Response {
     @javax.annotation.Nullable
     @JsonProperty("lastModified")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getLastModified() { return lastModified; }
-    public void setLastModified(OffsetDateTime lastModified) { this.lastModified = lastModified; }
+    public Date getLastModified() { return lastModified; }
+    public void setLastModified(Date lastModified) { this.lastModified = lastModified; }
 
     public Response location(URI location) {
         this.location = location;

--- a/java/src/main/java/com/ibm/watson/data/client/model/ResponseTermEntity.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/ResponseTermEntity.java
@@ -18,8 +18,8 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,7 +30,7 @@ public class ResponseTermEntity extends GlossaryObjectEntity {
 
     private List<String> abbreviations = null;
     private String importSourceCreatedBy;
-    private OffsetDateTime importSourceCreatedOn;
+    private Date importSourceCreatedOn;
     private String importSourceUsage;
     private String example;
     private String abbreviation;
@@ -91,7 +91,7 @@ public class ResponseTermEntity extends GlossaryObjectEntity {
     public String getImportSourceCreatedBy() { return importSourceCreatedBy; }
     public void setImportSourceCreatedBy(String importSourceCreatedBy) { this.importSourceCreatedBy = importSourceCreatedBy; }
 
-    public ResponseTermEntity importSourceCreatedOn(OffsetDateTime importSourceCreatedOn) {
+    public ResponseTermEntity importSourceCreatedOn(Date importSourceCreatedOn) {
         this.importSourceCreatedOn = importSourceCreatedOn;
         return this;
     }
@@ -104,8 +104,8 @@ public class ResponseTermEntity extends GlossaryObjectEntity {
     @javax.annotation.Nullable
     @JsonProperty("import_source_created_on")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getImportSourceCreatedOn() { return importSourceCreatedOn; }
-    public void setImportSourceCreatedOn(OffsetDateTime importSourceCreatedOn) { this.importSourceCreatedOn = importSourceCreatedOn; }
+    public Date getImportSourceCreatedOn() { return importSourceCreatedOn; }
+    public void setImportSourceCreatedOn(Date importSourceCreatedOn) { this.importSourceCreatedOn = importSourceCreatedOn; }
 
     public ResponseTermEntity importSourceUsage(String importSourceUsage) {
         this.importSourceUsage = importSourceUsage;

--- a/java/src/main/java/com/ibm/watson/data/client/model/SpaceMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/SpaceMetadata.java
@@ -17,8 +17,12 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.ibm.watson.data.client.serde.DateTimeMilliDeserializer;
+import com.ibm.watson.data.client.serde.DateTimeMilliSerializer;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -26,13 +30,20 @@ import java.util.Objects;
  */
 public class SpaceMetadata {
 
-    private OffsetDateTime createdAt;
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date createdAt;
+
     private String creatorId;
     private String id;
-    private OffsetDateTime updatedAt;
+
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date updatedAt;
+
     private String url;
 
-    public SpaceMetadata createdAt(OffsetDateTime createdAt) {
+    public SpaceMetadata createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -44,8 +55,8 @@ public class SpaceMetadata {
     @javax.annotation.Nullable
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     public SpaceMetadata creatorId(String creatorId) {
         this.creatorId = creatorId;
@@ -77,7 +88,7 @@ public class SpaceMetadata {
     public String getId() { return id; }
     public void setId(String id) { this.id = id; }
 
-    public SpaceMetadata updatedAt(OffsetDateTime updatedAt) {
+    public SpaceMetadata updatedAt(Date updatedAt) {
         this.updatedAt = updatedAt;
         return this;
     }
@@ -89,8 +100,8 @@ public class SpaceMetadata {
     @javax.annotation.Nullable
     @JsonProperty("updated_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getUpdatedAt() { return updatedAt; }
-    public void setUpdatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; }
+    public Date getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
 
     public SpaceMetadata url(String url) {
         this.url = url;

--- a/java/src/main/java/com/ibm/watson/data/client/model/StepInfo.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/StepInfo.java
@@ -15,11 +15,11 @@
  */
 package com.ibm.watson.data.client.model;
 
+import java.util.Date;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
 
 /**
  * Details about the step. 
@@ -28,8 +28,8 @@ public class StepInfo {
 
     private String id;
     private String name;
-    private OffsetDateTime startedAt;
-    private OffsetDateTime completedAt;
+    private Date startedAt;
+    private Date completedAt;
     private Object hyperParameters;
     private Integer dataAllocation;
     private String estimator;
@@ -65,7 +65,7 @@ public class StepInfo {
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
 
-    public StepInfo startedAt(OffsetDateTime startedAt) {
+    public StepInfo startedAt(Date startedAt) {
         this.startedAt = startedAt;
         return this;
     }
@@ -77,10 +77,10 @@ public class StepInfo {
     @javax.annotation.Nullable
     @JsonProperty("started_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getStartedAt() { return startedAt; }
-    public void setStartedAt(OffsetDateTime startedAt) { this.startedAt = startedAt; }
+    public Date getStartedAt() { return startedAt; }
+    public void setStartedAt(Date startedAt) { this.startedAt = startedAt; }
 
-    public StepInfo completedAt(OffsetDateTime completedAt) {
+    public StepInfo completedAt(Date completedAt) {
         this.completedAt = completedAt;
         return this;
     }
@@ -92,8 +92,8 @@ public class StepInfo {
     @javax.annotation.Nullable
     @JsonProperty("completed_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCompletedAt() { return completedAt; }
-    public void setCompletedAt(OffsetDateTime completedAt) { this.completedAt = completedAt; }
+    public Date getCompletedAt() { return completedAt; }
+    public void setCompletedAt(Date completedAt) { this.completedAt = completedAt; }
 
     public StepInfo hyperParameters(Object hyperParameters) {
         this.hyperParameters = hyperParameters;

--- a/java/src/main/java/com/ibm/watson/data/client/model/UserTaskEntity.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/UserTaskEntity.java
@@ -17,8 +17,8 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,9 +30,9 @@ public class UserTaskEntity {
     private String assignee;
     private List<String> candidateGroups = null;
     private List<String> candidateUsers = null;
-    private OffsetDateTime claimedAt;
-    private OffsetDateTime completedAt;
-    private OffsetDateTime dueDate;
+    private Date claimedAt;
+    private Date completedAt;
+    private Date dueDate;
     private String formKey;
     private List<FormProperty> formProperties = null;
     private String owner;
@@ -105,7 +105,7 @@ public class UserTaskEntity {
     public List<String> getCandidateUsers() { return candidateUsers; }
     public void setCandidateUsers(List<String> candidateUsers) { this.candidateUsers = candidateUsers; }
 
-    public UserTaskEntity claimedAt(OffsetDateTime claimedAt) {
+    public UserTaskEntity claimedAt(Date claimedAt) {
         this.claimedAt = claimedAt;
         return this;
     }
@@ -117,10 +117,10 @@ public class UserTaskEntity {
     @javax.annotation.Nullable
     @JsonProperty("claimed_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getClaimedAt() { return claimedAt; }
-    public void setClaimedAt(OffsetDateTime claimedAt) { this.claimedAt = claimedAt; }
+    public Date getClaimedAt() { return claimedAt; }
+    public void setClaimedAt(Date claimedAt) { this.claimedAt = claimedAt; }
 
-    public UserTaskEntity completedAt(OffsetDateTime completedAt) {
+    public UserTaskEntity completedAt(Date completedAt) {
         this.completedAt = completedAt;
         return this;
     }
@@ -132,10 +132,10 @@ public class UserTaskEntity {
     @javax.annotation.Nullable
     @JsonProperty("completed_at")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getCompletedAt() { return completedAt; }
-    public void setCompletedAt(OffsetDateTime completedAt) { this.completedAt = completedAt; }
+    public Date getCompletedAt() { return completedAt; }
+    public void setCompletedAt(Date completedAt) { this.completedAt = completedAt; }
 
-    public UserTaskEntity dueDate(OffsetDateTime dueDate) {
+    public UserTaskEntity dueDate(Date dueDate) {
         this.dueDate = dueDate;
         return this;
     }
@@ -147,8 +147,8 @@ public class UserTaskEntity {
     @javax.annotation.Nullable
     @JsonProperty("due_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getDueDate() { return dueDate; }
-    public void setDueDate(OffsetDateTime dueDate) { this.dueDate = dueDate; }
+    public Date getDueDate() { return dueDate; }
+    public void setDueDate(Date dueDate) { this.dueDate = dueDate; }
 
     public UserTaskEntity formKey(String formKey) {
         this.formKey = formKey;

--- a/java/src/main/java/com/ibm/watson/data/client/model/UserTaskMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/UserTaskMetadata.java
@@ -17,9 +17,13 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.ibm.watson.data.client.model.enums.UserTaskState;
+import com.ibm.watson.data.client.serde.DateTimeMilliDeserializer;
+import com.ibm.watson.data.client.serde.DateTimeMilliSerializer;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -28,7 +32,11 @@ import java.util.Objects;
 public class UserTaskMetadata {
 
     private String artifactType;
-    private OffsetDateTime createdAt;
+
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date createdAt;
+
     private String name;
     private UserTaskState state;
     private String taskId;
@@ -49,7 +57,7 @@ public class UserTaskMetadata {
     public String getArtifactType() { return artifactType; }
     public void setArtifactType(String artifactType) { this.artifactType = artifactType; }
 
-    public UserTaskMetadata createdAt(OffsetDateTime createdAt) {
+    public UserTaskMetadata createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -60,8 +68,8 @@ public class UserTaskMetadata {
      **/
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     public UserTaskMetadata name(String name) {
         this.name = name;

--- a/java/src/main/java/com/ibm/watson/data/client/model/WorkflowMetadata.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/WorkflowMetadata.java
@@ -17,9 +17,13 @@ package com.ibm.watson.data.client.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.ibm.watson.data.client.model.enums.WorkflowState;
+import com.ibm.watson.data.client.serde.DateTimeMilliDeserializer;
+import com.ibm.watson.data.client.serde.DateTimeMilliSerializer;
 
-import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -28,10 +32,18 @@ import java.util.Objects;
 public class WorkflowMetadata {
 
     private String artifactType;
-    private OffsetDateTime createdAt;
+
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date createdAt;
+
     private String createdBy;
     private String description;
-    private OffsetDateTime modifiedAt;
+
+    @JsonSerialize(using = DateTimeMilliSerializer.class)
+    @JsonDeserialize(using = DateTimeMilliDeserializer.class)
+    private Date modifiedAt;
+
     private String modifiedBy;
     private String name;
     private WorkflowState state;
@@ -52,7 +64,7 @@ public class WorkflowMetadata {
     public String getArtifactType() { return artifactType; }
     public void setArtifactType(String artifactType) { this.artifactType = artifactType; }
 
-    public WorkflowMetadata createdAt(OffsetDateTime createdAt) {
+    public WorkflowMetadata createdAt(Date createdAt) {
         this.createdAt = createdAt;
         return this;
     }
@@ -63,8 +75,8 @@ public class WorkflowMetadata {
      **/
     @JsonProperty("created_at")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
 
     public WorkflowMetadata createdBy(String createdBy) {
         this.createdBy = createdBy;
@@ -95,7 +107,7 @@ public class WorkflowMetadata {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
 
-    public WorkflowMetadata modifiedAt(OffsetDateTime modifiedAt) {
+    public WorkflowMetadata modifiedAt(Date modifiedAt) {
         this.modifiedAt = modifiedAt;
         return this;
     }
@@ -106,8 +118,8 @@ public class WorkflowMetadata {
      **/
     @JsonProperty("modified_at")
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
-    public OffsetDateTime getModifiedAt() { return modifiedAt; }
-    public void setModifiedAt(OffsetDateTime modifiedAt) { this.modifiedAt = modifiedAt; }
+    public Date getModifiedAt() { return modifiedAt; }
+    public void setModifiedAt(Date modifiedAt) { this.modifiedAt = modifiedAt; }
 
     public WorkflowMetadata modifiedBy(String modifiedBy) {
         this.modifiedBy = modifiedBy;

--- a/java/src/main/java/com/ibm/watson/data/client/model/WriteableGlossaryObjectEntity.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/WriteableGlossaryObjectEntity.java
@@ -18,8 +18,8 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,8 +30,8 @@ public class WriteableGlossaryObjectEntity extends GlossaryObjectEntity {
 
     private String name;
     private String shortDescription;
-    private OffsetDateTime effectiveStartDate;
-    private OffsetDateTime effectiveEndDate;
+    private Date effectiveStartDate;
+    private Date effectiveEndDate;
     private List<String> tags = null;
     private List<String> stewardIds = null;
     private NewRelationship parentCategory;
@@ -66,7 +66,7 @@ public class WriteableGlossaryObjectEntity extends GlossaryObjectEntity {
     public String getShortDescription() { return shortDescription; }
     public void setShortDescription(String shortDescription) { this.shortDescription = shortDescription; }
 
-    public WriteableGlossaryObjectEntity effectiveStartDate(OffsetDateTime effectiveStartDate) {
+    public WriteableGlossaryObjectEntity effectiveStartDate(Date effectiveStartDate) {
         this.effectiveStartDate = effectiveStartDate;
         return this;
     }
@@ -80,10 +80,10 @@ public class WriteableGlossaryObjectEntity extends GlossaryObjectEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_start_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveStartDate() { return effectiveStartDate; }
-    public void setEffectiveStartDate(OffsetDateTime effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
+    public Date getEffectiveStartDate() { return effectiveStartDate; }
+    public void setEffectiveStartDate(Date effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
 
-    public WriteableGlossaryObjectEntity effectiveEndDate(OffsetDateTime effectiveEndDate) {
+    public WriteableGlossaryObjectEntity effectiveEndDate(Date effectiveEndDate) {
         this.effectiveEndDate = effectiveEndDate;
         return this;
     }
@@ -97,8 +97,8 @@ public class WriteableGlossaryObjectEntity extends GlossaryObjectEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_end_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveEndDate() { return effectiveEndDate; }
-    public void setEffectiveEndDate(OffsetDateTime effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
+    public Date getEffectiveEndDate() { return effectiveEndDate; }
+    public void setEffectiveEndDate(Date effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
 
     public WriteableGlossaryObjectEntity tags(List<String> tags) {
         this.tags = tags;

--- a/java/src/main/java/com/ibm/watson/data/client/model/WriteableReferenceDataSetEntity.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/WriteableReferenceDataSetEntity.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ibm.watson.data.client.model.enums.GlossaryObjectState;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -31,8 +31,8 @@ public class WriteableReferenceDataSetEntity {
 
     private String name;
     private String longDescription;
-    private OffsetDateTime effectiveStartDate;
-    private OffsetDateTime effectiveEndDate;
+    private Date effectiveStartDate;
+    private Date effectiveEndDate;
     private GlossaryObjectState state;
     private List<String> tags = null;
     private List<String> stewardIds = null;
@@ -72,7 +72,7 @@ public class WriteableReferenceDataSetEntity {
     public String getLongDescription() { return longDescription; }
     public void setLongDescription(String longDescription) { this.longDescription = longDescription; }
 
-    public WriteableReferenceDataSetEntity effectiveStartDate(OffsetDateTime effectiveStartDate) {
+    public WriteableReferenceDataSetEntity effectiveStartDate(Date effectiveStartDate) {
         this.effectiveStartDate = effectiveStartDate;
         return this;
     }
@@ -86,10 +86,10 @@ public class WriteableReferenceDataSetEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_start_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveStartDate() { return effectiveStartDate; }
-    public void setEffectiveStartDate(OffsetDateTime effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
+    public Date getEffectiveStartDate() { return effectiveStartDate; }
+    public void setEffectiveStartDate(Date effectiveStartDate) { this.effectiveStartDate = effectiveStartDate; }
 
-    public WriteableReferenceDataSetEntity effectiveEndDate(OffsetDateTime effectiveEndDate) {
+    public WriteableReferenceDataSetEntity effectiveEndDate(Date effectiveEndDate) {
         this.effectiveEndDate = effectiveEndDate;
         return this;
     }
@@ -103,8 +103,8 @@ public class WriteableReferenceDataSetEntity {
     @javax.annotation.Nullable
     @JsonProperty("effective_end_date")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getEffectiveEndDate() { return effectiveEndDate; }
-    public void setEffectiveEndDate(OffsetDateTime effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
+    public Date getEffectiveEndDate() { return effectiveEndDate; }
+    public void setEffectiveEndDate(Date effectiveEndDate) { this.effectiveEndDate = effectiveEndDate; }
 
     public WriteableReferenceDataSetEntity state(GlossaryObjectState state) {
         this.state = state;

--- a/java/src/main/java/com/ibm/watson/data/client/model/WriteableTermEntity.java
+++ b/java/src/main/java/com/ibm/watson/data/client/model/WriteableTermEntity.java
@@ -18,8 +18,8 @@ package com.ibm.watson.data.client.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,7 +30,7 @@ public class WriteableTermEntity extends WriteableGlossaryObjectEntity {
 
     private List<String> abbreviations = null;
     private String importSourceCreatedBy;
-    private OffsetDateTime importSourceCreatedOn;
+    private Date importSourceCreatedOn;
     private String importSourceUsage;
     private String example;
     private List<RelationshipObject> relatedTermRelationships = null;
@@ -84,7 +84,7 @@ public class WriteableTermEntity extends WriteableGlossaryObjectEntity {
     public String getImportSourceCreatedBy() { return importSourceCreatedBy; }
     public void setImportSourceCreatedBy(String importSourceCreatedBy) { this.importSourceCreatedBy = importSourceCreatedBy; }
 
-    public WriteableTermEntity importSourceCreatedOn(OffsetDateTime importSourceCreatedOn) {
+    public WriteableTermEntity importSourceCreatedOn(Date importSourceCreatedOn) {
         this.importSourceCreatedOn = importSourceCreatedOn;
         return this;
     }
@@ -97,8 +97,8 @@ public class WriteableTermEntity extends WriteableGlossaryObjectEntity {
     @javax.annotation.Nullable
     @JsonProperty("import_source_created_on")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    public OffsetDateTime getImportSourceCreatedOn() { return importSourceCreatedOn; }
-    public void setImportSourceCreatedOn(OffsetDateTime importSourceCreatedOn) { this.importSourceCreatedOn = importSourceCreatedOn; }
+    public Date getImportSourceCreatedOn() { return importSourceCreatedOn; }
+    public void setImportSourceCreatedOn(Date importSourceCreatedOn) { this.importSourceCreatedOn = importSourceCreatedOn; }
 
     public WriteableTermEntity importSourceUsage(String importSourceUsage) {
         this.importSourceUsage = importSourceUsage;

--- a/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeBaseDeserializer.java
+++ b/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeBaseDeserializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.watson.data.client.serde;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+
+/**
+ * Custom deserialization for Dates, to handle the variations that exist in the API endpoints
+ * and underlying meta-model, where some dates have millisecond-level detail and others do not.
+ */
+public abstract class DateTimeBaseDeserializer extends StdDeserializer<Date> {
+
+    private DateFormat dateFormat;
+
+    protected DateTimeBaseDeserializer(DateFormat dateFormat) {
+        super(Date.class);
+        this.dateFormat = dateFormat;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        String date = p.getText();
+        try {
+            return dateFormat.parse(date);
+        } catch (ParseException e) {
+            throw new IOException("Unable to parse date and time: " + date, e);
+        }
+    }
+
+}

--- a/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeBaseSerializer.java
+++ b/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeBaseSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.watson.data.client.serde;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.util.Date;
+
+/**
+ * Custom serialization for Dates, to handle the variations that exist in the API endpoints
+ * and underlying meta-model, where some dates have millisecond-level detail and others do not.
+ */
+public abstract class DateTimeBaseSerializer extends StdSerializer<Date> {
+
+    private DateFormat dateFormat;
+
+    protected DateTimeBaseSerializer(DateFormat dateFormat) {
+        super(Date.class);
+        this.dateFormat = dateFormat;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void serialize(Date value, JsonGenerator gen, SerializerProvider provider) throws IOException, JsonProcessingException {
+        gen.writeString(dateFormat.format(value));
+    }
+
+}

--- a/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeMilliDeserializer.java
+++ b/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeMilliDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.watson.data.client.serde;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+/**
+ * Custom deserialization for Dates, to handle deserialization of date and timestamps
+ * with millisecond-level detail.
+ */
+public class DateTimeMilliDeserializer extends DateTimeBaseDeserializer {
+
+    public static final DateFormat DATE_FORMAT = createDateFormat();
+    private static DateFormat createDateFormat() {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format;
+    }
+
+    protected DateTimeMilliDeserializer() {
+        super(DATE_FORMAT);
+    }
+
+}

--- a/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeMilliSerializer.java
+++ b/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeMilliSerializer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.watson.data.client.serde;
+
+/**
+ * Custom serialization for Dates, to handle serialization of date and timestamps
+ * with millisecond-level detail.
+ */
+public class DateTimeMilliSerializer extends DateTimeBaseSerializer {
+    protected DateTimeMilliSerializer() {
+        super(DateTimeMilliDeserializer.DATE_FORMAT);
+    }
+}

--- a/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeNoMilliDeserializer.java
+++ b/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeNoMilliDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.watson.data.client.serde;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+/**
+ * Custom deserialization for Dates, to handle deserialization of date and timestamps
+ * without millisecond-level detail.
+ */
+public class DateTimeNoMilliDeserializer extends DateTimeBaseDeserializer {
+
+    public static final DateFormat DATE_FORMAT = createDateFormat();
+    private static DateFormat createDateFormat() {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format;
+    }
+
+    protected DateTimeNoMilliDeserializer() {
+        super(DATE_FORMAT);
+    }
+
+}

--- a/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeNoMilliSerializer.java
+++ b/java/src/main/java/com/ibm/watson/data/client/serde/DateTimeNoMilliSerializer.java
@@ -13,22 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ibm.watson.data.client;
+package com.ibm.watson.data.client.serde;
 
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
-import java.text.FieldPosition;
-import java.util.Date;
-
-public class RFC3339DateFormat extends ISO8601DateFormat {
-
-    // Same as ISO8601DateFormat but serializing milliseconds.
-    @Override
-    public StringBuffer format(Date date, StringBuffer toAppendTo,
-                               FieldPosition fieldPosition) {
-        String value = ISO8601Utils.format(date, true);
-        toAppendTo.append(value);
-        return toAppendTo;
+/**
+ * Custom serialization for Dates, to handle serialization of date and timestamps
+ * without millisecond-level detail.
+ */
+public class DateTimeNoMilliSerializer extends DateTimeBaseSerializer {
+    protected DateTimeNoMilliSerializer() {
+        super(DateTimeNoMilliDeserializer.DATE_FORMAT);
     }
-
 }

--- a/java/src/test/java/com/ibm/watson/data/client/mocks/AbstractExpectations.java
+++ b/java/src/test/java/com/ibm/watson/data/client/mocks/AbstractExpectations.java
@@ -18,6 +18,7 @@ package com.ibm.watson.data.client.mocks;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.watson.data.client.ApiClient;
 import org.mockserver.client.MockServerClient;
 
 import java.io.File;


### PR DESCRIPTION
Provides the foundation for #18, but further annotation still necessary in the individual model classes as to whether they use millisecond-level or only second-level details in their timestamps.